### PR TITLE
Fixed transparent menu issue on mobile

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -430,7 +430,7 @@ header .intro-text .owner {
         padding-left: 10px;
         margin-right: 10px;
         transition: all ease 1s;
-        background-color: #{{ site.color.primary }};
+        background-color: #{{ site.color.secondary }};
     }
 
     .navbar-toggler:hover {


### PR DESCRIPTION
Changed menu on mobile to use the secondary site color (gray), instead of white

![image](https://user-images.githubusercontent.com/10181187/96522762-57c29700-1231-11eb-928d-df1345bdd481.png)
