### PR TITLE
Added credits to the HIRO group website

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
                     </div>
                     <div class="col-lg-4">
                         <h3>Credits</h3>
-                        <p class="small">Made with <a href="http://jekyllrb.com/">Jekyll for Github</a>. The design is modified from the beautiful <a href="https://github.com/jeromelachaud/freelancer-theme">Freelancer Theme</a>.</p>
+                        <p class="small">Made with <a href="http://jekyllrb.com/">Jekyll for Github</a>. The design is modified from the <a href="https://hiro-group.ronc.one">HIRO-group website</a>.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
As per title, I have modified the footer to credit https://hiro-group.ronc.one rather than the freelancer website given that the freelancer theme is probably 2% of the whole web design. 